### PR TITLE
Update to latest  substrate, fix contract 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -130,7 +130,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-macros 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,7 +159,7 @@ dependencies = [
  "kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -181,7 +181,7 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -197,7 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -207,7 +207,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -621,7 +621,7 @@ dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -673,17 +673,6 @@ dependencies = [
 name = "doc-comment"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ed25519-dalek"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ed25519-dalek"
@@ -773,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -787,7 +776,7 @@ name = "fdlimit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -808,7 +797,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -822,7 +811,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -844,26 +833,15 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -875,30 +853,6 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "frame-support"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -928,35 +882,12 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -968,17 +899,7 @@ dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -988,24 +909,7 @@ source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a8
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-system"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1031,7 +935,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1135,7 +1039,7 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1235,7 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1245,7 +1149,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1254,7 +1158,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1280,7 +1184,7 @@ name = "grafana-data-source"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "async-std 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1305,7 +1209,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1323,7 +1227,7 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1385,7 +1289,7 @@ name = "hermit-abi"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1431,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1446,7 +1350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1456,7 +1360,7 @@ version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1481,7 +1385,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1492,12 +1396,12 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1511,7 +1415,7 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1586,7 +1490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1612,7 +1516,7 @@ name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1631,7 +1535,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1645,13 +1549,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1672,31 +1576,31 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-client-transports 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1705,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1716,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1731,11 +1635,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1814,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1858,7 +1762,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1889,7 +1793,7 @@ dependencies = [
  "rw-stream-sink 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2009,7 +1913,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2138,7 +2042,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2204,7 +2108,7 @@ dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2217,7 +2121,7 @@ dependencies = [
  "hmac-drbg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2227,7 +2131,7 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2280,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2292,7 +2196,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2321,9 +2225,10 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2336,13 +2241,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "merlin"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2355,14 +2260,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2377,7 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2387,8 +2293,8 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2429,7 +2335,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2441,7 +2347,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2508,7 +2414,7 @@ version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2554,55 +2460,36 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "pallet-contracts"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -2630,8 +2517,8 @@ version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2639,18 +2526,6 @@ dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "pallet-contracts-rpc-runtime-api"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -2668,140 +2543,140 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -2891,7 +2766,7 @@ dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2908,11 +2783,6 @@ dependencies = [
  "malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "parity-wasm"
-version = "0.40.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-wasm"
@@ -2953,7 +2823,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2967,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2982,7 +2852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3006,7 +2876,7 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3048,7 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3097,7 +2967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3107,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3135,16 +3005,6 @@ dependencies = [
 name = "protobuf"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "pwasm-utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "pwasm-utils"
@@ -3182,7 +3042,7 @@ name = "rand"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3192,7 +3052,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3204,7 +3064,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3222,7 +3082,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3296,7 +3156,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3308,7 +3168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3389,7 +3249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3401,7 +3261,7 @@ name = "rocksdb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb-sys 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3410,7 +3270,7 @@ name = "rpassword"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3475,9 +3335,9 @@ dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3531,12 +3391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "merlin 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3592,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3711,7 +3571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3736,7 +3596,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3748,7 +3608,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3770,7 +3630,7 @@ source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a8
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
@@ -3782,34 +3642,11 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "sp-finality-tracker"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -3857,20 +3694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "sr-api"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3885,38 +3708,13 @@ dependencies = [
 [[package]]
 name = "sr-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sr-api-proc-macro"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sr-arithmetic"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3935,23 +3733,6 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "sr-io"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3964,25 +3745,6 @@ dependencies = [
  "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "sr-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -4007,18 +3769,6 @@ dependencies = [
 [[package]]
 name = "sr-sandbox"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sr-sandbox"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4031,34 +3781,17 @@ dependencies = [
 [[package]]
 name = "sr-staking-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
-
-[[package]]
-name = "sr-std"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
 
 [[package]]
 name = "sr-std"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
-
-[[package]]
-name = "sr-version"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
 
 [[package]]
 name = "sr-version"
@@ -4121,13 +3854,8 @@ dependencies = [
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "strum"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strum"
@@ -4139,36 +3867,13 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "strum_macros"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-application-crypto"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4232,18 +3937,6 @@ dependencies = [
 [[package]]
 name = "substrate-block-builder-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-block-builder-runtime-api"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4281,7 +3974,7 @@ dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4444,20 +4137,6 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-consensus-aura-primitives"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4526,21 +4205,11 @@ dependencies = [
 [[package]]
 name = "substrate-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-debug-derive"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4565,17 +4234,6 @@ dependencies = [
  "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-externalities"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -4614,21 +4272,8 @@ dependencies = [
  "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-finality-grandpa-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4647,18 +4292,6 @@ dependencies = [
 [[package]]
 name = "substrate-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-inherents"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4666,18 +4299,6 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "substrate-keyring"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -4703,7 +4324,7 @@ dependencies = [
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
- "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4725,7 +4346,7 @@ dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4781,28 +4402,10 @@ dependencies = [
 [[package]]
 name = "substrate-offchain-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-offchain-primitives"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "substrate-panic-handler"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4823,45 +4426,6 @@ dependencies = [
  "libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4906,17 +4470,6 @@ dependencies = [
 [[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-primitives-storage"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4933,7 +4486,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4969,9 +4522,9 @@ version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4993,6 +4546,7 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
@@ -5001,6 +4555,7 @@ dependencies = [
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
@@ -5019,50 +4574,35 @@ dependencies = [
 name = "substrate-runtime-contract-sample-runtime"
 version = "2.0.0"
 dependencies = [
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-wasm-builder-runner 1.0.4 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-runtime-interface"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-wasm-builder-runner 1.0.4 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -5083,25 +4623,13 @@ dependencies = [
 [[package]]
 name = "substrate-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-runtime-interface-proc-macro"
-version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5156,19 +4684,9 @@ dependencies = [
  "substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-session"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
 ]
 
 [[package]]
@@ -5190,25 +4708,6 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
-]
-
-[[package]]
-name = "substrate-state-machine"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5269,36 +4768,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-transaction-pool-runtime-api"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-trie"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "substrate-trie"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
@@ -5309,16 +4784,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.4"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-
-[[package]]
-name = "substrate-wasm-interface"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 
 [[package]]
 name = "substrate-wasm-interface"
@@ -5336,7 +4802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -5351,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5366,7 +4832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5377,7 +4843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5429,7 +4895,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5463,18 +4929,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5517,7 +4983,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5533,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-executor"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5584,18 +5050,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-reactor"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5640,9 +5106,9 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5658,18 +5124,18 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-timer"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5680,10 +5146,10 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5694,13 +5160,13 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5742,7 +5208,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5752,18 +5218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5981,7 +5435,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6013,7 +5467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6028,12 +5482,12 @@ name = "wasm-bindgen-webidl"
 version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6046,7 +5500,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6056,20 +5510,12 @@ name = "wasmi"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi-validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6085,7 +5531,7 @@ name = "web-sys"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6131,7 +5577,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6189,7 +5635,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6246,6 +5692,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "zeroize"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
@@ -6257,7 +5717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-"checksum anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1072d8f55592084072d2d3cb23a4b680a8543c00f10d446118e85ad3718142"
+"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
@@ -6266,7 +5726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum asn1_der 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6fce6b6a0ffdafebd82c87e79e3f40e8d2c523e5fea5566ff6b90509bf98d638"
 "checksum asn1_der_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 "checksum async-macros 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "644a5a8de80f2085a1e7e57cd1544a2a7438f6e003c0790999bd43b92a77cdb2"
-"checksum async-std 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56933da6903b273923d13f4746d829f66ff9b444173f6743d831e80f4da15446"
+"checksum async-std 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "513ee3c49800679a319912340f5601afda9e72848d7dea3a48bab489e8c1a46f"
 "checksum async-task 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de6bd58f7b9cc49032559422595c81cbfcf04db2f2133592f70af19e258a1ced"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
@@ -6328,7 +5788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
-"checksum ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d07e8b8a8386c3b89a7a4b329fdfa4cb545de2545e9e2ebbc3dd3929253e426"
 "checksum ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "073be79b6538296faf81c631872676600616073817dd9a440c477ad09b408983"
@@ -6346,18 +5805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -6404,7 +5857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hex-literal-impl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d4c5c844e2fee0bf673d54c2c177f1713b3d2af2ff6e666b49cb7572e6cf42d"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum hmac-drbg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-"checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
+"checksum http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3aef6f3de2bd8585f5b366f3f550b5774500b4764d00cf00f903c95749eec3"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
@@ -6425,14 +5878,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
-"checksum jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d389a085cb2184604dff060390cadb8cba1f063c7fd0ad710272c163c88b9f20"
+"checksum jsonrpc-client-transports 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9ae166c4d1f702d297cd76d4b55758ace80272ffc6dbb139fdc1bf810de40b"
 "checksum jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
-"checksum jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbaec1d57271ff952f24ca79d37d716cfd749c855b058d9aa5f053a6b8ae4ef"
-"checksum jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d5c31575cc70a8b21542599028472c80a9248394aeea4d8918a045a0ab08a3"
-"checksum jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aa54c4c2d88cb5e04b251a5031ba0f2ee8c6ef30970e31228955b89a80c3b611"
-"checksum jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ee1b8da0b9219a231c4b7cbc7110bfdb457cbcd8d90a6224d0b3cab8aae8443"
-"checksum jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "87bc3c0a9a282211b2ec14abb3e977de33016bbec495332e9f7be858de7c5117"
-"checksum jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af36a129cef77a9db8028ac7552d927e1bb7b6928cd96b23dd25cc38bff974ab"
+"checksum jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "080dc110be17701097df238fad3c816d4a478a1899dfbcf8ec8957dd40ec7304"
+"checksum jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
+"checksum jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2d83d348120edee487c560b7cdd2565055d61cda053aa0d0ef0f8b6a18429048"
+"checksum jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3453625f0f0f5cd6d6776d389d73b7d70fcc98620b7cbb1cbbb1f6a36e95f39a"
+"checksum jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95b7635e618a0edbbe0d2a2bbbc69874277c49383fcf6c3c0414491cfb517d22"
+"checksum jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b34faa167c3ac9705aeecb986c0da6056529f348425dbe0441db60a2c4cc41d1"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
@@ -6441,7 +5894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kvdb-rocksdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f82177237c1ae67d6ab208a6f790cab569a1d81c1ba02348e0736a99510be3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fab3090cd3af0f0ff5e6c2cc0f6fe6607e9f9282680cf7cd3bdd4cda38ea722"
 "checksum libp2p-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a3def059145c191b6975e51784d5edc59e77e1ed5b25402fccac704dd7731f3"
@@ -6472,17 +5925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26b0dca4ac5b5083c5169ab12205e6473df1c7659940e4978b94f363c6b54b22"
+"checksum lru 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a57ada89b072a15fa9e1b9d1e18d0e161fd25a47e0a3ae4868cf53aada8ba97"
 "checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef49315991403ba5fa225a70399df5e115f57b274cb0b1b4bcd6e734fa5bd783"
+"checksum memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5dabfe0a8c69954ae3bcfc5fc14260a85fb80e1bf9f86a155f668d10a67e93dd"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
-"checksum merlin 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "de2d16d3b15fec5943d1144f861f61f279d165fdd60998ca262913b9bf1c8adb"
+"checksum merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
-"checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
@@ -6504,22 +5957,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum pallet-contracts-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 "checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82afcb7461eae5d122543d8be1c57d306ed89af2d6ff7f8b0f5a3cc8f7e511bc"
@@ -6529,7 +5980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parity-scale-codec-derive 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "492ac3aa93d6caa5d20e4e3e0b75d08e2dcd9dd8a50d19529548b6fe11b3f295"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 "checksum parity-util-mem 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "570093f39f786beea92dcc09e45d8aae7841516ac19a50431953ac82a0e8f85c"
-"checksum parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1e39faaa292a687ea15120b1ac31899b13586446521df6c149e46f1584671e0f"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
@@ -6557,7 +6007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40361836defdd5871ff7e84096c6f6444af7fc157f8ef1789f54f147687caa20"
-"checksum pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d473123ba135028544926f7aa6f34058d8bc6f120c4fcd3777f84af724280b3"
 "checksum pwasm-utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -6625,29 +6074,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum soketto 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bceb1a3a15232d013d9a3b7cac9e5ce8e2313f348f01d4bc1097e5e53aa07095"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -6656,16 +6095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
 "checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
-"checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
-"checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
-"checksum substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
 "checksum substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-build-script-utils 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
@@ -6675,61 +6110,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
-"checksum substrate-wasm-builder-runner 1.0.4 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-wasm-builder-runner 1.0.4 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
+"checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+"checksum syn 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f89693ae015201f8de93fd96bde2d065f8bfc3f97ce006d5bc9f900b97c0c7c0"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4b2468c629cffba39c0a4425849ab3cdb03d9dfacba69684609aea04d08ff9"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
@@ -6747,18 +6165,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tokio-codec 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9f5d22fd1e84bd4045d28813491cb7d7caae34d45c80517c2213f09a85e8787a"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-dns-unofficial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82c65483db54eb91b4ef3a9389a3364558590faf30ce473141707c0e16fda975"
-"checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
+"checksum tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 "checksum tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee9ceecf69145923834ea73f32ba40c790fd877b74a7817dd0b089f1eb9c7c8"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
-"checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
+"checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 "checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1aaeb685540f7407ea0e27f1c9757d258c7c6bf4e3eb19da6fc59b747239d2"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
-"checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
+"checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
@@ -6767,7 +6185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4e4f59e752cb3beb5b61c6d5e11191c7946231ba84faec2902c9efdd8691c5"
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
-"checksum trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b62d27e8aa1c07414549ac872480ac82380bab39e730242ab08d82d7cc098a"
 "checksum trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "784a9813d23f18bccab728ab039c39b8a87d0d6956dcdece39e92f5cffe5076e"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
@@ -6804,7 +6221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wasm-bindgen-webidl 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "3126356474ceb717c8fb5549ae387c9fbf4872818454f4d87708bee997214bb5"
 "checksum wasm-timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aa3e01d234bb71760e685cfafa5e2c96f8ad877c161a721646356651069e26ac"
 "checksum wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bf617d864d25af3587aa745529f7aaa541066c876d57e050c0d0c85c61c92aff"
-"checksum wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6bc0356e3df56e639fc7f7d8a99741915531e27ed735d911ed83d7e1339c8188"
 "checksum wasmi-validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 "checksum web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "98405c0a2e722ed3db341b4c5b70eb9fe0021621f7350bab76df93b09b649bbf"
 "checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
@@ -6826,3 +6242,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2758f29014c1cb7a6e74c1b1160ac8c8203be342d35b73462fc6a13cc6385423"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdc979d9b5ead18184c357c4d8a3f81b579aae264e32507223032e64715462d3"
+"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,7 +836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -857,6 +867,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "frame-support"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -881,11 +902,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-support"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
 dependencies = [
  "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -904,9 +960,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-support-procedural-tools"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -928,6 +1006,23 @@ dependencies = [
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "frame-system"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -1183,16 +1278,17 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "async-std 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1291,11 +1387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hex"
@@ -1676,30 +1767,30 @@ dependencies = [
 [[package]]
 name = "kvdb"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd#03a2ba08f47f4af4219280e660a1ea92cb8896bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-bytes 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
 version = "0.1.2"
-source = "git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd#03a2ba08f47f4af4219280e660a1ea92cb8896bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.1.6"
-source = "git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd#03a2ba08f47f4af4219280e660a1ea92cb8896bd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2515,20 +2606,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-contracts"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pwasm-utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "wasmi-validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pallet-contracts-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -2541,6 +2651,18 @@ dependencies = [
  "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "pallet-contracts-rpc-runtime-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -2685,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "parity-bytes"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd#03a2ba08f47f4af4219280e660a1ea92cb8896bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-multiaddr"
@@ -3025,6 +3147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pwasm-utils"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,6 +3468,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-rpc-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
+name = "sc-transaction-graph"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
+name = "sc-transaction-pool"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "schnorrkel"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,12 +3706,12 @@ dependencies = [
 
 [[package]]
 name = "slog_derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3575,6 +3764,22 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sp-blockchain"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -3582,6 +3787,16 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "sp-finality-tracker"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -3595,6 +3810,43 @@ dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
+name = "sp-transaction-pool-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
+name = "sp-transaction-pool-runtime-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -3617,9 +3869,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sr-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "sr-api-proc-macro"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sr-api-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3642,6 +3920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sr-arithmetic"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "sr-io"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -3656,6 +3947,23 @@ dependencies = [
  "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "sr-io"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -3678,6 +3986,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sr-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "sr-sandbox"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -3686,6 +4013,18 @@ dependencies = [
  "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sr-sandbox"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3705,6 +4044,11 @@ version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
 
 [[package]]
+name = "sr-std"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+
+[[package]]
 name = "sr-version"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -3714,6 +4058,18 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+]
+
+[[package]]
+name = "sr-version"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -3774,6 +4130,14 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strum"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,6 +4146,17 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3797,22 +4172,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-application-crypto"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-basic-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3829,14 +4218,15 @@ dependencies = [
 [[package]]
 name = "substrate-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -3852,29 +4242,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-block-builder-runtime-api"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 
 [[package]]
 name = "substrate-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3885,13 +4287,13 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3902,18 +4304,18 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3921,119 +4323,122 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-client-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
- "kvdb-memorydb 0.1.2 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
- "kvdb-rocksdb 0.1.6 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)",
+ "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-consensus-aura"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -4051,56 +4456,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-consensus-aura-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-consensus-slots"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -4114,26 +4534,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-debug-derive"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-executor"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4149,12 +4579,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-externalities"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "finality-grandpa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "finality-grandpa 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4162,18 +4602,18 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4192,13 +4632,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-header-metadata"
+name = "substrate-finality-grandpa-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -4214,6 +4657,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-inherents"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-keyring"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -4226,32 +4681,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-keyring"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-network"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4267,18 +4733,18 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4288,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4302,13 +4768,13 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4322,6 +4788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-offchain-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-panic-handler"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -4331,9 +4806,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-panic-handler"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4381,6 +4865,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -4392,9 +4915,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-primitives-storage"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4403,57 +4937,36 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-rpc-api"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-rpc-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
 name = "substrate-rpc-servers"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4462,7 +4975,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -4475,28 +4988,28 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "pallet-contracts-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "pallet-contracts-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-build-script-utils 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-build-script-utils 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "substrate-runtime-contract-sample-runtime 2.0.0",
- "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4553,6 +5066,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-runtime-interface"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-runtime-interface-proc-macro"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -4565,9 +5093,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-runtime-interface-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4576,42 +5116,44 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4630,14 +5172,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-session"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+]
+
+[[package]]
 name = "substrate-state-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
 ]
 
 [[package]]
@@ -4660,9 +5212,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-state-machine"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4684,43 +5255,17 @@ dependencies = [
 [[package]]
 name = "substrate-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate-transaction-graph"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
-]
-
-[[package]]
-name = "substrate-transaction-pool"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
-dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
- "substrate-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4748,6 +5293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-trie"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
+dependencies = [
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)",
+ "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.4"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
@@ -4756,6 +5315,15 @@ source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef
 name = "substrate-wasm-interface"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41#77e681fb8b9c1e98ef1441bcc648e40ee36dac41"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "substrate-wasm-interface"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4#e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4978,6 +5546,8 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5187,6 +5757,18 @@ dependencies = [
 [[package]]
 name = "trie-db"
 version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5742,6 +6324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+"checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
@@ -5758,18 +6341,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
-"checksum finality-grandpa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b36ece7dc398ce17438d815f3202d2cdba8fd930452a68b616965662742b7e10"
+"checksum finality-grandpa 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bd555755b04f83d6ed3041f5da26c0123a417ae2b96a826c1171b3f6fb804803"
 "checksum fixed-hash 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72fe7539e2c5692c6989f2f9c0457e42f1e5768f96b85c87d273574670ae459f"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -5800,7 +6389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
-"checksum grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f107db1419ef8271686187b1a5d47c6431af4a7f4d98b495e7b7fc249bb0a78"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -5810,7 +6399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
-"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
 "checksum hex-literal-impl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d4c5c844e2fee0bf673d54c2c177f1713b3d2af2ff6e666b49cb7572e6cf42d"
@@ -5848,9 +6436,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
-"checksum kvdb 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)" = "<none>"
-"checksum kvdb-memorydb 0.1.2 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)" = "<none>"
-"checksum kvdb-rocksdb 0.1.6 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)" = "<none>"
+"checksum kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c1b2f251f01a7224426abdb2563707d856f7de995d821744fd8fa8e2874f69e3"
+"checksum kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "296c12309ed36cb74d59206406adbf1971c3baa56d5410efdb508d8f1c60a351"
+"checksum kvdb-rocksdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f82177237c1ae67d6ab208a6f790cab569a1d81c1ba02348e0736a99510be3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
@@ -5919,8 +6507,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum pallet-contracts-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum pallet-contracts 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum pallet-contracts-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum pallet-contracts-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
@@ -5930,7 +6520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum parity-bytes 0.1.1 (git+https://github.com/paritytech/parity-common?rev=03a2ba08f47f4af4219280e660a1ea92cb8896bd)" = "<none>"
+"checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 "checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82afcb7461eae5d122543d8be1c57d306ed89af2d6ff7f8b0f5a3cc8f7e511bc"
 "checksum parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
@@ -5968,6 +6558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40361836defdd5871ff7e84096c6f6444af7fc157f8ef1789f54f147687caa20"
 "checksum pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d473123ba135028544926f7aa6f34058d8bc6f120c4fcd3777f84af724280b3"
+"checksum pwasm-utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -6003,6 +6594,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rw-stream-sink 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9cbe61c20455d3015b2bb7be39e1872310283b8e5a52f5b242b0ac7581fe78"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f7bf422d23a88c16d5090d455f182bc99c60af4df6a345c63428acf5129e347"
+"checksum sc-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -6024,24 +6618,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slog-async 2.3.0 (git+https://github.com/paritytech/slog-async)" = "<none>"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
-"checksum slog_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eff3b513cf2e0d1a60e1aba152dc72bedc5b05585722bb3cebd7bcb1e31b98f"
+"checksum slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum snow 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91eecae35b461ed26bda7a76bea2cc5bda2bf4b8dd06761879f19e6fdd50c2dd"
 "checksum soketto 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bceb1a3a15232d013d9a3b7cac9e5ce8e2313f348f01d4bc1097e5e53aa07095"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-sandbox 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum sr-version 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
@@ -6050,59 +6657,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
 "checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
+"checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
+"checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-block-builder 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-build-script-utils 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-block-builder-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-build-script-utils 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-client-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-network 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-service 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-session 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
-"checksum substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
+"checksum substrate-tracing 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.4 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
 "checksum substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=77e681fb8b9c1e98ef1441bcc648e40ee36dac41)" = "<none>"
+"checksum substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4)" = "<none>"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -6145,6 +6768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
 "checksum trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b62d27e8aa1c07414549ac872480ac82380bab39e730242ab08d82d7cc098a"
+"checksum trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "784a9813d23f18bccab728ab039c39b8a87d0d6956dcdece39e92f5cffe5076e"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-consensus-aura'
 rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
+[dependencies.consensus-common]
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-consensus-common'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
+
 [dependencies.contracts]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-contracts'
@@ -118,9 +123,14 @@ rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 git = 'https://github.com/paritytech/substrate.git'
 rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
-[dependencies.transaction-pool]
+[dependencies.txpool]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sc-transaction-pool'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
+
+[dependencies.txpool-api]
+git = 'https://github.com/paritytech/substrate.git'
+package = 'sp-transaction-pool-api'
 rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ vergen = '3.0.4'
 [build-dependencies.build-script-utils]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-build-script-utils'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [[bin]]
 name = 'substrate-runtime-contract-sample'
@@ -27,22 +27,22 @@ trie-root = '0.15.2'
 [dependencies.aura]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-consensus-aura'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.contracts]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-contracts'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.aura-primitives]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-consensus-aura-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.basic-authorship]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-basic-authorship'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.codec]
 package = 'parity-scale-codec'
@@ -59,32 +59,32 @@ version = '0.1.29'
 [dependencies.grandpa]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-finality-grandpa'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.grandpa-primitives]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-finality-grandpa-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.inherents]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-inherents'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.network]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-network'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.pallet-contracts-rpc]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-contracts-rpc'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.primitives]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.runtime]
 package = 'substrate-runtime-contract-sample-runtime'
@@ -92,36 +92,36 @@ path = 'runtime'
 
 [dependencies.sr-io]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.sr-primitives]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-cli]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-client]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-executor]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-rpc]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-service]
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.transaction-pool]
 git = 'https://github.com/paritytech/substrate.git'
-package = 'substrate-transaction-pool'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+package = 'sc-transaction-pool'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [package]
 authors = ['Anonymous']

--- a/contracts/custom_type/Cargo.toml
+++ b/contracts/custom_type/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 ink_abi = { git = "https://github.com/paritytech/ink", package = "ink_abi", default-features = false, features = ["derive"], optional = true }
 ink_core = { git = "https://github.com/paritytech/ink", package = "ink_core", default-features = false }
 ink_lang2 = { git = "https://github.com/paritytech/ink", package = "ink_lang2", default-features = false }
+ink_prelude = { git = "https://github.com/paritytech/ink", package = "ink_prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/contracts/custom_type/lib.rs
+++ b/contracts/custom_type/lib.rs
@@ -1,7 +1,7 @@
 #![feature(proc_macro_hygiene)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_core::memory::{
+use ink_prelude::{
     format,
     vec::Vec,
 };

--- a/contracts/custom_type/lib.rs
+++ b/contracts/custom_type/lib.rs
@@ -1,6 +1,7 @@
 #![feature(proc_macro_hygiene)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use scale::KeyedVec as _;
 use ink_prelude::{
     format,
     vec::Vec,
@@ -63,13 +64,14 @@ mod custom_type {
         /// Returns `None` if the key does not exist, or it failed to decode the value.
         #[ink(message)]
         fn read_custom_runtime(&self) -> Option<Foo> {
-            // The raw key for a storage Value is `<ModuleName> <ValueName>`
-            let raw_key = b"TemplateModule FooStore";
-            // A storage Value key is hashed using `twox_128`
-            let hashed_key = hashing::twox_128(&raw_key[..]);
+            // A storage key is constructed as `Twox128(module_prefix) ++ Twox128(storage_prefix)`
+            let module_prefix = hashing::twox_128(&b"TemplateModule"[..]);
+            let storage_prefix = hashing::twox_128(&b"FooStore"[..]);
+            let key = module_prefix.to_keyed_vec(&storage_prefix);
+            self.env().println(&format!("Storage key: {:?}", key));
 
             // Attempt to read and decode the value directly from the runtime storage
-            let result = self.env().get_runtime_storage::<Foo>(&hashed_key[..]);
+            let result = self.env().get_runtime_storage::<Foo>(&key[..]);
             match result {
                 Ok(foo) => {
                     // Return the successfully decoded instance of `Foo`

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [build-dependencies.wasm-builder-runner]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-wasm-builder-runner'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 version = '1.0.4'
 
 [package]
@@ -46,25 +46,25 @@ std = [
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-aura'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.aura-primitives]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-consensus-aura-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.balances]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-balances'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.block-builder-api]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-block-builder-runtime-api'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.codec]
 default-features = false
@@ -76,67 +76,67 @@ version = '1.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-contracts'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.contracts-rpc-runtime-api]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-contracts-rpc-runtime-api'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.executive]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'frame-executive'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.grandpa]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-grandpa'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.indices]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-indices'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.inherents]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-inherents'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.offchain-primitives]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-offchain-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.primitives]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-primitives'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.randomness-collective-flip]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-randomness-collective-flip'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.rstd]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-std'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.runtime-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-io'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.safe-mix]
 default-features = false
@@ -150,56 +150,56 @@ version = '1.0.101'
 [dependencies.sr-api]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.sr-primitives]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.substrate-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.sudo]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-sudo'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'frame-support'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'frame-system'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.timestamp]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-timestamp'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.transaction-payment]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-transaction-payment'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.tx-pool-api]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-package = 'substrate-transaction-pool-runtime-api'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+package = 'sp-transaction-pool-runtime-api'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'
 
 [dependencies.version]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-version'
-rev = '77e681fb8b9c1e98ef1441bcc648e40ee36dac41'
+rev = 'e3245d49dc55c9e3a88ab3e45ff4a0c4d37750c4'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,8 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 			Ok(new_full_start!(config).0), load_spec, exit),
 		ParseAndPrepare::ImportBlocks(cmd) => cmd.run_with_builder(|config: Config<_>|
 			Ok(new_full_start!(config).0), load_spec, exit),
+		ParseAndPrepare::CheckBlock(cmd) => cmd.run_with_builder(|config: Config<_>|
+			Ok(new_full_start!(config).0), load_spec, exit),
 		ParseAndPrepare::PurgeChain(cmd) => cmd.run(load_spec),
 		ParseAndPrepare::RevertChain(cmd) => cmd.run_with_builder(|config: Config<_>|
 			Ok(new_full_start!(config).0), load_spec),

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use substrate_client::LongestChain;
 use runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
 use substrate_service::{error::{Error as ServiceError}, AbstractService, Configuration, ServiceBuilder};
-use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use inherents::InherentDataProviders;
 use network::{construct_simple_protocol};
 use substrate_executor::native_executor_instance;
@@ -42,9 +41,13 @@ macro_rules! new_full_start {
 			.with_select_chain(|_config, backend| {
 				Ok(substrate_client::LongestChain::new(backend.clone()))
 			})?
-			.with_transaction_pool(|config, client|
-				Ok(transaction_pool::txpool::Pool::new(config, transaction_pool::FullChainApi::new(client)))
-			)?
+			.with_transaction_pool(|config, client, _fetcher| {
+				let pool_api = txpool::FullChainApi::new(client.clone());
+				let pool = txpool::BasicPool::new(config, pool_api);
+				let maintainer = txpool::FullBasicPoolMaintainer::new(pool.pool().clone(), client);
+				let maintainable_pool = txpool_api::MaintainableTransactionPool::new(pool, maintainer);
+				Ok(maintainable_pool)
+			})?
 			.with_import_queue(|_config, client, mut select_chain, transaction_pool| {
 				let select_chain = select_chain.take()
 					.ok_or_else(|| substrate_service::Error::SelectChainRequired)?;
@@ -68,7 +71,7 @@ macro_rules! new_full_start {
 
 				Ok(import_queue)
 			})?
-			.with_rpc_extensions(|client, _pool, _backend| -> RpcExtension {
+			.with_rpc_extensions(|client, _pool, _backend, _, _| -> Result<RpcExtension, _> {
 				use pallet_contracts_rpc::{Contracts, ContractsApi};
 
 				// register contracts RPC extension
@@ -76,7 +79,7 @@ macro_rules! new_full_start {
 				io.extend_with(
 					ContractsApi::to_delegate(Contracts::new(client.clone()))
 				);
-				io
+				Ok(io)
 			})?;
 
 		(builder, import_setup, inherent_data_providers)
@@ -119,7 +122,10 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 		let select_chain = service.select_chain()
 			.ok_or(ServiceError::SelectChainRequired)?;
 
-		let aura = aura::start_aura::<_, _, _, _, _, AuraPair, _, _, _>(
+		let can_author_with =
+			consensus_common::CanAuthorWithNativeVersion::new(client.executor().clone());
+
+		let aura = aura::start_aura::<_, _, _, _, _, AuraPair, _, _, _, _>(
 			aura::SlotDuration::get_or_compute(&*client)?,
 			client,
 			select_chain,
@@ -129,6 +135,7 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 			inherent_data_providers.clone(),
 			force_authoring,
 			service.keystore(),
+			can_author_with,
 		)?;
 
 		// the AURA authoring task is considered essential, i.e. if it
@@ -202,9 +209,15 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 		.with_select_chain(|_config, backend| {
 			Ok(LongestChain::new(backend.clone()))
 		})?
-		.with_transaction_pool(|config, client|
-			Ok(TransactionPool::new(config, transaction_pool::FullChainApi::new(client)))
-		)?
+		.with_transaction_pool(|config, client, fetcher| {
+			let fetcher = fetcher
+				.ok_or_else(|| "Trying to start light transaction pool without active fetcher")?;
+			let pool_api = txpool::LightChainApi::new(client.clone(), fetcher.clone());
+			let pool = txpool::BasicPool::new(config, pool_api);
+			let maintainer = txpool::LightBasicPoolMaintainer::with_defaults(pool.pool().clone(), client, fetcher);
+			let maintainable_pool = txpool_api::MaintainableTransactionPool::new(pool, maintainer);
+			Ok(maintainable_pool)
+		})?
 		.with_import_queue_and_fprb(|_config, client, backend, fetcher, _select_chain, _tx_pool| {
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())


### PR DESCRIPTION
The key scheme in substrate has recently changed (https://github.com/paritytech/substrate/pull/4227). This PR updates to latest version of substrate and modified the contract to use the new key hashing scheme.

Also fixes contract compilation with `ink_prelude`